### PR TITLE
Update cursive to 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ num = "0.2.0"
 
 [dev-dependencies]
 serde_json = "1.0.40"
+cursive = "0.14"
 
 [badges]
 travis-ci = { repository = "deinstapel/cursive-tabs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/cursive-tabs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cursive = "0.13.0"
+cursive = {version = "0.14.0", default-features = false }
 crossbeam = "0.7.2"
 log = "0.4.8"
 num = "0.2.0"

--- a/examples/bottom.rs
+++ b/examples/bottom.rs
@@ -3,20 +3,20 @@ use cursive::views::{Button, LinearLayout, PaddedView, TextArea, TextView};
 use cursive::Cursive;
 use cursive_tabs::{Align, Placement, TabPanel};
 
-const TAB_0: &'static str =
+const TAB_0: &str =
     "With using the TabPanel you get a TabView and TabBar, preconfigured for you to use!
 Simply create it with:
 
 `cursive_tabs::TabPanel::new()`";
 
-const TAB_1: &'static str = "You then can add views and configure your panel.";
+const TAB_1: &str = "You then can add views and configure your panel.";
 
-const TAB_2: &'static str =
+const TAB_2: &str =
     "Ofcourse you can also use the provided TabView without the panel, simply create it with:
 
 `cursive_tabs::TabView::new()`";
 
-const TAB_3: &'static str = "All you have to do is add:
+const TAB_3: &str = "All you have to do is add:
 
 cursive-tabs = \"^0\"
 

--- a/examples/bottom.rs
+++ b/examples/bottom.rs
@@ -1,4 +1,4 @@
-use cursive::view::{Boxable, Identifiable, Margins};
+use cursive::view::{Boxable, Identifiable};
 use cursive::views::{Button, LinearLayout, PaddedView, TextArea, TextView};
 use cursive::Cursive;
 use cursive_tabs::{Align, Placement, TabPanel};

--- a/examples/bottom.rs
+++ b/examples/bottom.rs
@@ -30,7 +30,7 @@ fn main() {
         .with_tab(1, TextView::new(TAB_1))
         .with_tab(2, TextView::new(TAB_2))
         .with_tab(3, TextView::new(TAB_3))
-        .with_tab(4, PaddedView::new((2, 2, 1, 1), TextArea::new()))
+        .with_tab(4, PaddedView::lrtb(2, 2, 1, 1, TextArea::new()))
         .with_bar_alignment(Align::End)
         .with_bar_placement(Placement::HorizontalBottom)
         .with_active_tab(0)
@@ -38,22 +38,22 @@ fn main() {
 
     siv.add_layer(
         LinearLayout::vertical()
-            .child(panel.with_id("Tabs").fixed_size((50, 10)))
+            .child(panel.with_name("Tabs").fixed_size((50, 10)))
             .child(
                 LinearLayout::horizontal()
                     .child(Button::new("Prev", |siv| {
                         let mut tabs: cursive::views::ViewRef<TabPanel<i32>> =
-                            siv.find_id("Tabs").expect("id not found");
+                            siv.find_name("Tabs").expect("id not found");
                         tabs.prev();
                     }))
                     .child(Button::new("Next", |siv| {
                         let mut tabs: cursive::views::ViewRef<TabPanel<i32>> =
-                            siv.find_id("Tabs").expect("id not found");
+                            siv.find_name("Tabs").expect("id not found");
                         tabs.next();
                     }))
                     .child(Button::new("Switch", |siv| {
                         let mut tabs: cursive::views::ViewRef<TabPanel<i32>> =
-                            siv.find_id("Tabs").expect("id not found");
+                            siv.find_name("Tabs").expect("id not found");
                         tabs.swap_tabs(1, 2);
                     })),
             ),

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -3,20 +3,20 @@ use cursive::views::{Button, LinearLayout, PaddedView, TextArea, TextView};
 use cursive::Cursive;
 use cursive_tabs::{Align, TabPanel};
 
-const TAB_0: &'static str =
+const TAB_0: &str =
     "With using the TabPanel you get a TabView and TabBar, preconfigured for you to use!
 Simply create it with:
 
 `cursive_tabs::TabPanel::new()`";
 
-const TAB_1: &'static str = "You then can add views and configure your panel.";
+const TAB_1: &str = "You then can add views and configure your panel.";
 
-const TAB_2: &'static str =
+const TAB_2: &str =
     "Ofcourse you can also use the provided TabView without the panel, simply create it with:
 
 `cursive_tabs::TabView::new()`";
 
-const TAB_3: &'static str = "All you have to do is add:
+const TAB_3: &str = "All you have to do is add:
 
 cursive-tabs = \"^0\"
 

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -1,4 +1,4 @@
-use cursive::view::{Boxable, Identifiable, Margins};
+use cursive::view::{Boxable, Identifiable};
 use cursive::views::{Button, LinearLayout, PaddedView, TextArea, TextView};
 use cursive::Cursive;
 use cursive_tabs::{Align, TabPanel};

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -30,24 +30,24 @@ fn main() {
         .with_tab(1, TextView::new(TAB_1))
         .with_tab(2, TextView::new(TAB_2))
         .with_tab(3, TextView::new(TAB_3))
-        .with_tab(4, PaddedView::new((2, 2, 1, 1), TextArea::new()))
+        .with_tab(4, PaddedView::lrtb(2, 2, 1, 1, TextArea::new()))
         .with_bar_alignment(Align::End)
         .with_active_tab(0)
         .expect("oh no");
 
     siv.add_fullscreen_layer(
         LinearLayout::vertical()
-            .child(panel.with_id("Tabs").full_screen())
+            .child(panel.with_name("Tabs").full_screen())
             .child(
                 LinearLayout::horizontal()
                     .child(Button::new("Prev", |siv| {
                         let mut tabs: cursive::views::ViewRef<TabPanel<i32>> =
-                            siv.find_id("Tabs").expect("id not found");
+                            siv.find_name("Tabs").expect("id not found");
                         tabs.prev();
                     }))
                     .child(Button::new("Next", |siv| {
                         let mut tabs: cursive::views::ViewRef<TabPanel<i32>> =
-                            siv.find_id("Tabs").expect("id not found");
+                            siv.find_name("Tabs").expect("id not found");
                         tabs.next();
                     })),
             ),

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -30,29 +30,29 @@ fn main() {
         .with_tab(1, TextView::new(TAB_1))
         .with_tab(2, TextView::new(TAB_2))
         .with_tab(3, TextView::new(TAB_3))
-        .with_tab(4, PaddedView::new((2, 2, 1, 1), TextArea::new()))
+        .with_tab(4, PaddedView::lrtb(2, 2, 1, 1, TextArea::new()))
         .with_bar_alignment(Align::End)
         .with_active_tab(0)
         .expect("oh no");
 
     siv.add_layer(
         LinearLayout::vertical()
-            .child(panel.with_id("Tabs").fixed_size((50, 10)))
+            .child(panel.with_name("Tabs").fixed_size((50, 10)))
             .child(
                 LinearLayout::horizontal()
                     .child(Button::new("Prev", |siv| {
                         let mut tabs: cursive::views::ViewRef<TabPanel<i32>> =
-                            siv.find_id("Tabs").expect("id not found");
+                            siv.find_name("Tabs").expect("id not found");
                         tabs.prev();
                     }))
                     .child(Button::new("Next", |siv| {
                         let mut tabs: cursive::views::ViewRef<TabPanel<i32>> =
-                            siv.find_id("Tabs").expect("id not found");
+                            siv.find_name("Tabs").expect("id not found");
                         tabs.next();
                     }))
                     .child(Button::new("Switch", |siv| {
                         let mut tabs: cursive::views::ViewRef<TabPanel<i32>> =
-                            siv.find_id("Tabs").expect("id not found");
+                            siv.find_name("Tabs").expect("id not found");
                         tabs.swap_tabs(1, 2);
                     })),
             ),

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -3,20 +3,20 @@ use cursive::views::{Button, LinearLayout, PaddedView, TextArea, TextView};
 use cursive::Cursive;
 use cursive_tabs::{Align, TabPanel};
 
-const TAB_0: &'static str =
+const TAB_0: &str =
     "With using the TabPanel you get a TabView and TabBar, preconfigured for you to use!
 Simply create it with:
 
 `cursive_tabs::TabPanel::new()`";
 
-const TAB_1: &'static str = "You then can add views and configure your panel.";
+const TAB_1: &str = "You then can add views and configure your panel.";
 
-const TAB_2: &'static str =
+const TAB_2: &str =
     "Ofcourse you can also use the provided TabView without the panel, simply create it with:
 
 `cursive_tabs::TabView::new()`";
 
-const TAB_3: &'static str = "All you have to do is add:
+const TAB_3: &str = "All you have to do is add:
 
 cursive-tabs = \"^0\"
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,4 +1,4 @@
-use cursive::view::{Boxable, Identifiable, Margins};
+use cursive::view::{Boxable, Identifiable};
 use cursive::views::{Button, LinearLayout, PaddedView, TextArea, TextView};
 use cursive::Cursive;
 use cursive_tabs::{Align, TabPanel};

--- a/examples/vertical.rs
+++ b/examples/vertical.rs
@@ -3,20 +3,20 @@ use cursive::views::{Button, LinearLayout, PaddedView, TextArea, TextView};
 use cursive::Cursive;
 use cursive_tabs::{Align, Placement, TabPanel};
 
-const TAB_0: &'static str =
+const TAB_0: &str =
     "With using the TabPanel you get a TabView and TabBar, preconfigured for you to use!
 Simply create it with:
 
 `cursive_tabs::TabPanel::new()`";
 
-const TAB_1: &'static str = "You then can add views and configure your panel.";
+const TAB_1: &str = "You then can add views and configure your panel.";
 
-const TAB_2: &'static str =
+const TAB_2: &str =
     "Ofcourse you can also use the provided TabView without the panel, simply create it with:
 
 `cursive_tabs::TabView::new()`";
 
-const TAB_3: &'static str = "All you have to do is add:
+const TAB_3: &str = "All you have to do is add:
 
 cursive-tabs = \"^0\"
 

--- a/examples/vertical.rs
+++ b/examples/vertical.rs
@@ -1,4 +1,4 @@
-use cursive::view::{Boxable, Identifiable, Margins};
+use cursive::view::{Boxable, Identifiable};
 use cursive::views::{Button, LinearLayout, PaddedView, TextArea, TextView};
 use cursive::Cursive;
 use cursive_tabs::{Align, Placement, TabPanel};

--- a/examples/vertical.rs
+++ b/examples/vertical.rs
@@ -30,7 +30,7 @@ fn main() {
         .with_tab(1, TextView::new(TAB_1))
         .with_tab(2, TextView::new(TAB_2))
         .with_tab(3, TextView::new(TAB_3))
-        .with_tab(4, PaddedView::new((2, 2, 1, 1), TextArea::new()))
+        .with_tab(4, PaddedView::lrtb(2, 2, 1, 1, TextArea::new()))
         .with_bar_alignment(Align::Start)
         .with_bar_placement(Placement::VerticalLeft)
         .with_active_tab(0)
@@ -38,22 +38,22 @@ fn main() {
 
     siv.add_layer(
         LinearLayout::vertical()
-            .child(panel.with_id("Tabs").fixed_size((50, 30)))
+            .child(panel.with_name("Tabs").fixed_size((50, 30)))
             .child(
                 LinearLayout::horizontal()
                     .child(Button::new("Prev", |siv| {
                         let mut tabs: cursive::views::ViewRef<TabPanel<i32>> =
-                            siv.find_id("Tabs").expect("id not found");
+                            siv.find_name("Tabs").expect("id not found");
                         tabs.prev();
                     }))
                     .child(Button::new("Next", |siv| {
                         let mut tabs: cursive::views::ViewRef<TabPanel<i32>> =
-                            siv.find_id("Tabs").expect("id not found");
+                            siv.find_name("Tabs").expect("id not found");
                         tabs.next();
                     }))
                     .child(Button::new("Switch", |siv| {
                         let mut tabs: cursive::views::ViewRef<TabPanel<i32>> =
-                            siv.find_id("Tabs").expect("id not found");
+                            siv.find_name("Tabs").expect("id not found");
                         tabs.swap_tabs(1, 2);
                     })),
             ),

--- a/examples/vertical_right.rs
+++ b/examples/vertical_right.rs
@@ -3,20 +3,20 @@ use cursive::views::{Button, LinearLayout, PaddedView, TextArea, TextView};
 use cursive::Cursive;
 use cursive_tabs::{Align, Placement, TabPanel};
 
-const TAB_0: &'static str =
+const TAB_0: &str =
     "With using the TabPanel you get a TabView and TabBar, preconfigured for you to use!
 Simply create it with:
 
 `cursive_tabs::TabPanel::new()`";
 
-const TAB_1: &'static str = "You then can add views and configure your panel.";
+const TAB_1: &str = "You then can add views and configure your panel.";
 
-const TAB_2: &'static str =
+const TAB_2: &str =
     "Ofcourse you can also use the provided TabView without the panel, simply create it with:
 
 `cursive_tabs::TabView::new()`";
 
-const TAB_3: &'static str = "All you have to do is add:
+const TAB_3: &str = "All you have to do is add:
 
 cursive-tabs = \"^0\"
 

--- a/examples/vertical_right.rs
+++ b/examples/vertical_right.rs
@@ -1,4 +1,4 @@
-use cursive::view::{Boxable, Identifiable, Margins};
+use cursive::view::{Boxable, Identifiable};
 use cursive::views::{Button, LinearLayout, PaddedView, TextArea, TextView};
 use cursive::Cursive;
 use cursive_tabs::{Align, Placement, TabPanel};

--- a/examples/vertical_right.rs
+++ b/examples/vertical_right.rs
@@ -30,7 +30,7 @@ fn main() {
         .with_tab(1, TextView::new(TAB_1))
         .with_tab(2, TextView::new(TAB_2))
         .with_tab(3, TextView::new(TAB_3))
-        .with_tab(4, PaddedView::new((2, 2, 1, 1), TextArea::new()))
+        .with_tab(4, PaddedView::lrtb(2, 2, 1, 1, TextArea::new()))
         .with_bar_alignment(Align::End)
         .with_bar_placement(Placement::VerticalRight)
         .with_active_tab(0)
@@ -38,22 +38,22 @@ fn main() {
 
     siv.add_layer(
         LinearLayout::vertical()
-            .child(panel.with_id("Tabs").fixed_size((50, 30)))
+            .child(panel.with_name("Tabs").fixed_size((50, 30)))
             .child(
                 LinearLayout::horizontal()
                     .child(Button::new("Prev", |siv| {
                         let mut tabs: cursive::views::ViewRef<TabPanel<i32>> =
-                            siv.find_id("Tabs").expect("id not found");
+                            siv.find_name("Tabs").expect("id not found");
                         tabs.prev();
                     }))
                     .child(Button::new("Next", |siv| {
                         let mut tabs: cursive::views::ViewRef<TabPanel<i32>> =
-                            siv.find_id("Tabs").expect("id not found");
+                            siv.find_name("Tabs").expect("id not found");
                         tabs.next();
                     }))
                     .child(Button::new("Switch", |siv| {
                         let mut tabs: cursive::views::ViewRef<TabPanel<i32>> =
-                            siv.find_id("Tabs").expect("id not found");
+                            siv.find_name("Tabs").expect("id not found");
                         tabs.swap_tabs(1, 2);
                     })),
             ),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,9 +328,9 @@ impl<K: Hash + Eq + Copy + 'static> View for TabView<K> {
         }
     }
 
-    fn call_on_any<'a>(&mut self, slt: &Selector, mut cb: AnyCb<'a>) {
+    fn call_on_any<'a>(&mut self, slt: &Selector, cb: AnyCb<'a>) {
         for (_, view) in self.map.iter_mut() {
-            view.call_on_any(slt, Box::new(|any| cb(any)));
+            view.call_on_any(slt, cb);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,16 +10,14 @@
 //! ```
 //! # use cursive::{Cursive, views::{TextView, Dialog}};
 //! # use cursive_tabs::TabView;
-//! # fn main() {
-//! #   let mut siv = Cursive::default();
+//! # let mut siv = Cursive::default();
 //! let mut tabs = TabView::new();
-//! #   // That is all what is needed to display an empty TabView, but of course
-//! #   // you can add your own tabs now and switch them around as you want!
-//! #   tabs.add_tab("First", TextView::new("Our first view!"));
-//! #   siv.add_layer(Dialog::around(tabs));
-//! #   // When your done setting run cursive
-//! #   // siv.run();
-//! # }
+//! # // That is all what is needed to display an empty TabView, but of course
+//! # // you can add your own tabs now and switch them around as you want!
+//! # tabs.add_tab("First", TextView::new("Our first view!"));
+//! # siv.add_layer(Dialog::around(tabs));
+//! # // When your done setting run cursive
+//! # // siv.run();
 //! ```
 //! You can then use the provided methods to modify the content of the `TabView`
 //! Consuming and non-consuming are both provided.
@@ -28,16 +26,15 @@
 //! ```
 //! use cursive::{Cursive, views::{TextView, Dialog}};
 //! use cursive_tabs::TabView;
-//! fn main() {
-//!   let mut siv = Cursive::default();
-//!   let mut tabs = TabView::new();
-//!   // That is all what is needed to display an empty TabView, but of course
-//!   // you can add your own tabs now and switch them around as you want!
-//!   tabs.add_tab("First", TextView::new("Our first view!"));
-//!   siv.add_layer(Dialog::around(tabs));
-//!   // When your done setting run cursive
-//!   // siv.run();
-//! }
+//!
+//! let mut siv = Cursive::default();
+//! let mut tabs = TabView::new();
+//! // That is all what is needed to display an empty TabView, but of course
+//! // you can add your own tabs now and switch them around as you want!
+//! tabs.add_tab("First", TextView::new("Our first view!"));
+//! siv.add_layer(Dialog::around(tabs));
+//! // When your done setting run cursive
+//! // siv.run();
 //! ```
 use crossbeam::{Receiver, Sender};
 use cursive::direction::Direction;
@@ -65,13 +62,18 @@ pub struct TabView<K: Hash> {
     invalidated: bool,
 }
 
+impl<K: Hash + Eq + Copy + 'static> Default for TabView<K> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<K: Hash + Eq + Copy + 'static> TabView<K> {
     /// Returns a new TabView
     /// # Example
     /// ```
     /// # use cursive::{Cursive, views::{TextView, Dialog}};
     /// # use cursive_tabs::TabView;
-    /// # fn main() {
     /// #  let mut siv = Cursive::default();
     /// let mut tabs = TabView::new();
     /// #  // That is all what is needed to display an empty TabView, but of course
@@ -80,7 +82,6 @@ impl<K: Hash + Eq + Copy + 'static> TabView<K> {
     /// #  siv.add_layer(Dialog::around(tabs));
     /// #  // When your done setting run cursive
     /// #  // siv.run();
-    /// # }
     /// ```
     pub fn new() -> Self {
         Self {
@@ -184,8 +185,9 @@ impl<K: Hash + Eq + Copy + 'static> TabView<K> {
                 _ => {}
             }
         }
-        if fst_pos.is_some() && snd_pos.is_some() {
-            self.key_order.swap(fst_pos.unwrap(), snd_pos.unwrap());
+
+        if let (Some(fst_pos), Some(snd_pos)) = (fst_pos, snd_pos) {
+            self.key_order.swap(fst_pos, snd_pos);
         }
     }
 
@@ -193,7 +195,7 @@ impl<K: Hash + Eq + Copy + 'static> TabView<K> {
     /// If the removed tab is active at the moment, the `TabView` will unfocus it and
     /// the focus needs to be set manually afterwards, or a new view has to be inserted.
     pub fn remove_tab(&mut self, id: K) -> Result<(), ()> {
-        if let Some(_) = self.map.remove(&id) {
+        if self.map.remove(&id).is_some() {
             if let Some(key) = &self.current_id {
                 if *key == id {
                     // Current id no longer valid
@@ -223,7 +225,7 @@ impl<K: Hash + Eq + Copy + 'static> TabView<K> {
 
     // Returns the index of the key, length of the vector if the key is not included
     // This can be done with out sorting
-    fn index_key(cur_key: &K, key_order: &Vec<K>) -> usize {
+    fn index_key(cur_key: &K, key_order: &[K]) -> usize {
         for (idx, key) in key_order.iter().enumerate() {
             if *key == *cur_key {
                 return idx;

--- a/src/panel.rs
+++ b/src/panel.rs
@@ -527,8 +527,8 @@ impl<K: Hash + Eq + Copy + std::fmt::Display + 'static> View for TabPanel<K> {
         self.tabs.focus_view(slt)
     }
 
-    fn call_on_any<'a>(&mut self, slt: &Selector, mut cb: AnyCb<'a>) {
-        self.bar.call_on_any(slt, Box::new(|any| cb(any)));
-        self.tabs.call_on_any(slt, Box::new(|any| cb(any)));
+    fn call_on_any<'a>(&mut self, slt: &Selector, cb: AnyCb<'a>) {
+        self.bar.call_on_any(slt, cb);
+        self.tabs.call_on_any(slt, cb);
     }
 }


### PR DESCRIPTION
This patch consists of two commits:
* The first one updates the `cursive` dependency to version 0.14, and fixes the required changes.
* The second commit just fixes most warnings emitted by clippy (except for taking `self` by value in `Align::get_offset` as it would be a breaking change).

You can cherry-pick the first commit if you don't care about the clippy lints.