### PR TITLE
Update to cursive_core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ documentation = "https://docs.rs/cursive-tabs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cursive = { version = "0.14.0", default-features = false }
+cursive_core = { version = "0.1" }
 crossbeam = "0.7.3"
 log = "0.4.8"
 num = "0.2.1"
 
 [dev-dependencies]
 serde_json = "1.0.48"
-cursive = "0.14.0"
+cursive = "0.15.0"
 
 [badges]
 travis-ci = { repository = "deinstapel/cursive-tabs" }

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ Below it is the `TabView` showing the current tab.
 It can be created by simply calling new on `TabPanel` and views and customize it as you want, have a look at the [documentation](https://docs.rs/cursive-tabs) to see all options.
 
 ```rust
-use cursive::{TextView, Cursive}
+use cursive::TextView;
 use cursive_tabs::TabPanel;
 
-let mut siv = Cursive::default;
+let mut siv = cursive::default();
 
 //Create your panel and add tabs
 let mut panel = TabPanel::new()
@@ -78,10 +78,10 @@ This crate also provides a struct `TabView` you can use to add tabs and switch b
 The `TabView` can also be used to create your own Panel/Bar if you want to design your cursive environment a different way.
 
 ```rust
-use cursive::{views::TextView, Cursive};
+use cursive::{views::TextView};
 use cursive_tabs::TabView;
 
-let mut siv = Cursive::default();
+let mut siv = cursive::default();
 let tabs = TabView::new().with_tab(0, TextView::new("Our first tab!"));
 // We can continue to add as many tabs as we want!
 

--- a/examples/bottom.rs
+++ b/examples/bottom.rs
@@ -1,6 +1,5 @@
 use cursive::view::{Boxable, Identifiable};
 use cursive::views::{Button, LinearLayout, PaddedView, TextArea, TextView};
-use cursive::Cursive;
 use cursive_tabs::{Align, Placement, TabPanel};
 
 const TAB_0: &str =
@@ -24,7 +23,7 @@ to your Cargo.toml!
 ";
 
 fn main() {
-    let mut siv = Cursive::default();
+    let mut siv = cursive::default();
     let panel = TabPanel::new()
         .with_tab(0, TextView::new(TAB_0))
         .with_tab(1, TextView::new(TAB_1))

--- a/examples/end2end_add_at.rs
+++ b/examples/end2end_add_at.rs
@@ -1,10 +1,8 @@
 use cursive::views::TextView;
 use cursive_tabs::TabView;
 
-use cursive::Cursive;
-
 fn main() {
-    let mut siv = Cursive::default();
+    let mut siv = cursive::default();
     let tabs = TabView::new()
         .with_tab_at(0, TextView::new("Third"), 0)
         .with_tab_at(1, TextView::new("First"), 0)

--- a/examples/end2end_add_at_panel.rs
+++ b/examples/end2end_add_at_panel.rs
@@ -1,16 +1,13 @@
 use cursive::views::TextView;
 use cursive_tabs::{Align, TabPanel};
 
-use cursive::Cursive;
-
 fn main() {
-    let mut siv = Cursive::default();
-    let mut tabs = TabPanel::new()
+    let mut siv = cursive::default();
+    let tabs = TabPanel::new()
         .with_tab("Stonks", TextView::new("Pshhhh"))
         .with_tab_at("So", TextView::new("Fooooo"), 0)
         .with_tab_at("Much", TextView::new("Ahhhhh"), 1)
         .with_bar_alignment(Align::Center);
-    tabs.swap_tabs("So", "Stonks");
     siv.add_layer(tabs);
     siv.run();
 }

--- a/examples/end2end_panel_smoke.rs
+++ b/examples/end2end_panel_smoke.rs
@@ -1,10 +1,8 @@
 use cursive::views::TextView;
 use cursive_tabs::{Align, TabPanel};
 
-use cursive::Cursive;
-
 fn main() {
-    let mut siv = Cursive::default();
+    let mut siv = cursive::default();
     let tabs = TabPanel::new()
         .with_tab("Stronk test", TextView::new("Pshhhh"))
         .with_active_tab("Stronk test")

--- a/examples/end2end_remove_active.rs
+++ b/examples/end2end_remove_active.rs
@@ -1,14 +1,12 @@
 use cursive::views::TextView;
 use cursive_tabs::TabView;
 
-use cursive::Cursive;
-
 fn main() {
-    let mut siv = Cursive::default();
+    let mut siv = cursive::default();
     let mut tabs = TabView::new()
         .with_tab(0, TextView::new("First"))
         .with_tab(1, TextView::new("Second"));
-    tabs.remove_tab(0).expect("Removal failed.");
+    tabs.remove_tab(1).expect("Removal of active tab failed");
     siv.add_layer(tabs);
     siv.run();
 }

--- a/examples/end2end_remove_inactive.rs
+++ b/examples/end2end_remove_inactive.rs
@@ -1,14 +1,12 @@
 use cursive::views::TextView;
 use cursive_tabs::TabView;
 
-use cursive::Cursive;
-
 fn main() {
-    let mut siv = Cursive::default();
+    let mut siv = cursive::default();
     let mut tabs = TabView::new()
         .with_tab(0, TextView::new("First"))
         .with_tab(1, TextView::new("Second"));
-    tabs.remove_tab(1).expect("Removal of active tab failed");
+    tabs.remove_tab(0).expect("Removal failed.");
     siv.add_layer(tabs);
     siv.run();
 }

--- a/examples/end2end_swap.rs
+++ b/examples/end2end_swap.rs
@@ -1,15 +1,14 @@
 use cursive::views::TextView;
 use cursive_tabs::{Align, TabPanel};
 
-use cursive::Cursive;
-
 fn main() {
-    let mut siv = Cursive::default();
-    let tabs = TabPanel::new()
+    let mut siv = cursive::default();
+    let mut tabs = TabPanel::new()
         .with_tab("Stonks", TextView::new("Pshhhh"))
         .with_tab_at("So", TextView::new("Fooooo"), 0)
         .with_tab_at("Much", TextView::new("Ahhhhh"), 1)
         .with_bar_alignment(Align::Center);
+    tabs.swap_tabs("So", "Stonks");
     siv.add_layer(tabs);
     siv.run();
 }

--- a/examples/end2end_switch.rs
+++ b/examples/end2end_switch.rs
@@ -1,10 +1,8 @@
 use cursive::views::TextView;
 use cursive_tabs::TabView;
 
-use cursive::Cursive;
-
 fn main() {
-    let mut siv = Cursive::default();
+    let mut siv = cursive::default();
     let tabs = TabView::new()
         .with_tab(0, TextView::new("First"))
         .with_tab(1, TextView::new("Second"))

--- a/examples/end2end_vertical_left.rs
+++ b/examples/end2end_vertical_left.rs
@@ -1,22 +1,20 @@
 use cursive::views::TextView;
 use cursive_tabs::{Align, Placement, TabPanel};
 
-use cursive::Cursive;
-
 fn main() {
-    let mut siv = Cursive::default();
+    let mut siv = cursive::default();
     let tabs = TabPanel::new()
-        .with_tab("Si!", TextView::new("Pshhhh"))
-        .with_tab("Ridiculous!", TextView::new("Pshhhh"))
-        .with_tab("A much shorter one", TextView::new("Pshhhh"))
         .with_tab(
             "A very long and strong description",
             TextView::new("Pshhhh"),
         )
+        .with_tab("A much shorter one", TextView::new("Pshhhh"))
+        .with_tab("Ridiculous!", TextView::new("Pshhhh"))
+        .with_tab("Si!", TextView::new("Pshhhh"))
         .with_active_tab("Si!")
         .expect("Setting active tab has failed")
         .with_bar_alignment(Align::Center)
-        .with_bar_placement(Placement::VerticalRight);
+        .with_bar_placement(Placement::VerticalLeft);
     siv.add_layer(tabs);
     siv.run();
 }

--- a/examples/end2end_vertical_right.rs
+++ b/examples/end2end_vertical_right.rs
@@ -1,22 +1,20 @@
 use cursive::views::TextView;
 use cursive_tabs::{Align, Placement, TabPanel};
 
-use cursive::Cursive;
-
 fn main() {
-    let mut siv = Cursive::default();
+    let mut siv = cursive::default();
     let tabs = TabPanel::new()
+        .with_tab("Si!", TextView::new("Pshhhh"))
+        .with_tab("Ridiculous!", TextView::new("Pshhhh"))
+        .with_tab("A much shorter one", TextView::new("Pshhhh"))
         .with_tab(
             "A very long and strong description",
             TextView::new("Pshhhh"),
         )
-        .with_tab("A much shorter one", TextView::new("Pshhhh"))
-        .with_tab("Ridiculous!", TextView::new("Pshhhh"))
-        .with_tab("Si!", TextView::new("Pshhhh"))
         .with_active_tab("Si!")
         .expect("Setting active tab has failed")
         .with_bar_alignment(Align::Center)
-        .with_bar_placement(Placement::VerticalLeft);
+        .with_bar_placement(Placement::VerticalRight);
     siv.add_layer(tabs);
     siv.run();
 }

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -1,6 +1,5 @@
 use cursive::view::{Boxable, Identifiable};
 use cursive::views::{Button, LinearLayout, PaddedView, TextArea, TextView};
-use cursive::Cursive;
 use cursive_tabs::{Align, TabPanel};
 
 const TAB_0: &str =
@@ -24,7 +23,7 @@ to your Cargo.toml!
 ";
 
 fn main() {
-    let mut siv = Cursive::default();
+    let mut siv = cursive::default();
     let panel = TabPanel::new()
         .with_tab(0, TextView::new(TAB_0))
         .with_tab(1, TextView::new(TAB_1))

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,6 +1,5 @@
 use cursive::view::{Boxable, Identifiable};
 use cursive::views::{Button, LinearLayout, PaddedView, TextArea, TextView};
-use cursive::Cursive;
 use cursive_tabs::{Align, TabPanel};
 
 const TAB_0: &str =
@@ -24,7 +23,7 @@ to your Cargo.toml!
 ";
 
 fn main() {
-    let mut siv = Cursive::default();
+    let mut siv = cursive::default();
     let panel = TabPanel::new()
         .with_tab(0, TextView::new(TAB_0))
         .with_tab(1, TextView::new(TAB_1))

--- a/examples/vertical.rs
+++ b/examples/vertical.rs
@@ -1,6 +1,5 @@
 use cursive::view::{Boxable, Identifiable};
 use cursive::views::{Button, LinearLayout, PaddedView, TextArea, TextView};
-use cursive::Cursive;
 use cursive_tabs::{Align, Placement, TabPanel};
 
 const TAB_0: &str =
@@ -24,7 +23,7 @@ to your Cargo.toml!
 ";
 
 fn main() {
-    let mut siv = Cursive::default();
+    let mut siv = cursive::default();
     let panel = TabPanel::new()
         .with_tab(0, TextView::new(TAB_0))
         .with_tab(1, TextView::new(TAB_1))

--- a/examples/vertical_right.rs
+++ b/examples/vertical_right.rs
@@ -1,6 +1,5 @@
 use cursive::view::{Boxable, Identifiable};
 use cursive::views::{Button, LinearLayout, PaddedView, TextArea, TextView};
-use cursive::Cursive;
 use cursive_tabs::{Align, Placement, TabPanel};
 
 const TAB_0: &str =
@@ -24,7 +23,7 @@ to your Cargo.toml!
 ";
 
 fn main() {
-    let mut siv = Cursive::default();
+    let mut siv = cursive::default();
     let panel = TabPanel::new()
         .with_tab(0, TextView::new(TAB_0))
         .with_tab(1, TextView::new(TAB_1))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,8 @@
 //! // When your done setting run cursive
 //! // siv.run();
 //! ```
+extern crate cursive_core as cursive;
+
 use crossbeam::{Receiver, Sender};
 use cursive::direction::Direction;
 use cursive::event::{AnyCb, Event, EventResult};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,9 @@
 //! # Example
 //! All you need to do to create a new `TabView` is:
 //! ```
-//! # use cursive::{Cursive, views::{TextView, Dialog}};
+//! # use cursive::{views::{TextView, Dialog}};
 //! # use cursive_tabs::TabView;
-//! # let mut siv = Cursive::default();
+//! # let mut siv = cursive::default();
 //! let mut tabs = TabView::new();
 //! # // That is all what is needed to display an empty TabView, but of course
 //! # // you can add your own tabs now and switch them around as you want!
@@ -24,10 +24,10 @@
 //!
 //! # Full Example
 //! ```
-//! use cursive::{Cursive, views::{TextView, Dialog}};
+//! use cursive::{views::{TextView, Dialog}};
 //! use cursive_tabs::TabView;
 //!
-//! let mut siv = Cursive::default();
+//! let mut siv = cursive::default();
 //! let mut tabs = TabView::new();
 //! // That is all what is needed to display an empty TabView, but of course
 //! // you can add your own tabs now and switch them around as you want!
@@ -74,9 +74,9 @@ impl<K: Hash + Eq + Copy + 'static> TabView<K> {
     /// Returns a new TabView
     /// # Example
     /// ```
-    /// # use cursive::{Cursive, views::{TextView, Dialog}};
+    /// # use cursive::{views::{TextView, Dialog}};
     /// # use cursive_tabs::TabView;
-    /// #  let mut siv = Cursive::default();
+    /// #  let mut siv = cursive::default();
     /// let mut tabs = TabView::new();
     /// #  // That is all what is needed to display an empty TabView, but of course
     /// #  // you can add your own tabs now and switch them around as you want!

--- a/tests/end2end.test.js
+++ b/tests/end2end.test.js
@@ -4,10 +4,10 @@ setup();
 
 function cargo_e2e(name, custom) {
     return async () => {
-        await expect.command(`cargo build --bin end2end_${name}`)
+        await expect.command(`cargo build --example end2end_${name}`)
             .forExitCode(exp => exp.toBe(0));
         await expect.command(
-            `tmux new-session -x 80 -y 24 -d 'sh -c "TERM=xterm-256color ../target/debug/end2end_${name}"' \; set status off && sleep 0.05`
+            `tmux new-session -x 80 -y 24 -d 'sh -c "TERM=xterm-256color ../target/debug/examples/end2end_${name}"' \; set status off && sleep 0.06`
         ).forExitCode(exp => exp.toBe(0));
 
         if (!!custom) {


### PR DESCRIPTION
This changes the dependency from `cursive` to `cursive_core`.

`cursive_core` is basically `cursive` without backends, which hopefully will
reduce the breaking changes and version bumps, making it easier for 3rd-party
libraries to depend on. There's also no default feature on `cursive_core`.

Since it does not include backends, `cursive` is still used for tests and
examples.

This also moves the end2end binaries to `examples/`, as mentioned in #5. A better solution may be to just use the puppet backend like in the `puppet-backend-tests` branch.